### PR TITLE
proto/example: Add version and fill in process

### DIFF
--- a/proto/example.go
+++ b/proto/example.go
@@ -15,10 +15,28 @@ func main() {
 		Spec: &oci.Spec{
 			Platform: &oci.Platform{Os: proto.String("linux"), Arch: proto.String("x86_64")},
 			Process: &oci.Process{
-				Cwd: proto.String("/"),
+				Terminal: proto.Bool(true),
+				User: &oci.User{Type: oci.PlatformType_LINUX.Enum()},
+				Args: []string{"sh"},
+				Cwd: proto.String("/root"),
 				Env: []string{"TERM=linux"},
 			},
 		},
+	}
+
+	err := proto.SetExtension(s.Spec.Process.User, oci.E_Uid, proto.Int32(1))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = proto.SetExtension(s.Spec.Process.User, oci.E_Gid, proto.Int32(1))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = proto.SetExtension(s.Spec.Process.User, oci.E_AdditionalGids, []int32{5, 6})
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	buf, err := json.MarshalIndent(s, "", "  ")

--- a/proto/example.go
+++ b/proto/example.go
@@ -13,6 +13,7 @@ import (
 func main() {
 	s := oci.LinuxSpec{
 		Spec: &oci.Spec{
+			Version: proto.String("0.1.0"),
 			Platform: &oci.Platform{Os: proto.String("linux"), Arch: proto.String("x86_64")},
 			Process: &oci.Process{
 				Terminal: proto.Bool(true),


### PR DESCRIPTION
I thought it would be easier to judge JSON compatibility if I filled
in a few more fields.  The version addition is pretty minor, but I'm
having trouble getting the process fields to serialize.  With
78315052, I get:

```
$ make
go run ./example.go
{
  "spec": {
    "version": "0.1.0",
    "platform": {
      "os": "linux",
      "arch": "x86_64"
    },
    "process": {
      "terminal": true,
      "user": {
        "type": 1
      },
      "args": [
        "sh"
      ],
      "env": [
        "TERM=linux"
      ],
      "cwd": "/root"
    }
  }
}
```

The extension fields aren't serialized, and I expect that has
something to do with:

```
$ grep -B4 -A2 'extension.*json' go/config.pb.go 
type User struct {
        // Type so that receivers of this message can `switch` for the fields
        // expected
        Type             *PlatformType             `protobuf:"varint,1,opt,name=type,enum=oci.PlatformType" json:"type,omitempty"`
        XXX_extensions   map[int32]proto.Extension `json:"-"`
        XXX_unrecognized []byte                    `json:"-"`
}
```

I'll take a stab at the protobuf3 branch and see if I have better luck
there.

Feel free to pull these commits into your protobuf branch or not as
you see fit.
